### PR TITLE
fix: SheetLink - Fix for SwiftUI not liking quick fingers

### DIFF
--- a/Sources/OWOWKit/SwiftUI/Navigation/SheetLink.swift
+++ b/Sources/OWOWKit/SwiftUI/Navigation/SheetLink.swift
@@ -54,7 +54,11 @@ public struct SheetLink<Label, Content>: View where Label: View, Content: View {
     }
     
     public var body: some View {
-        Button(action: { isPresented = true }) {
+        Button(action: {
+            if !isPresented {
+                isPresented = true
+            }
+        }) {
             label
         }
         .sheet(isPresented: _isPresented, onDismiss: onDismiss, content: content)


### PR DESCRIPTION
The `.sheet(...)` modifier in SwiftUI could get a bit confused (meaning: not work anymore) when attempting to show a new sheet during a dismissal. `SheetLink` will now just ignore those taps until the state variable or binding has been reset (by the framework) to `false`.