### PR TITLE
Fixed a compile error on Swift 5.8

### DIFF
--- a/Sources/OWOWDeveloperTools/Storybook/Framework/Rendering/StoryArgumentView.swift
+++ b/Sources/OWOWDeveloperTools/Storybook/Framework/Rendering/StoryArgumentView.swift
@@ -18,7 +18,7 @@ struct StoryArgumentView<Target>: View {
             case let keyPath as WritableKeyPath<Target, String>:
                 TextField(name, text: makeBinding(keyPath))
             default:
-                if let customUIType = type(of: keyPath).valueType as? CustomArgumentUIRendering.Type {
+                if let customUIType = type(of: keyPath).valueType as? any CustomArgumentUIRendering.Type {
                     customUIType.internalRenderArgumentUI(root: $target, keyPath: keyPath)
                 } else {
                     Text.storybook.unsupportedType(String(describing: type(of: keyPath).valueType))


### PR DESCRIPTION
Swift 5.8 broke compiling `OWOWDeveloperTools` with this error:

> OWOWKit-iOS/Sources/OWOWDeveloperTools/Storybook/Framework/Rendering/StoryArgumentView.swift:21:71 Use of protocol 'CustomArgumentUIRendering' as a type must be written 'any CustomArgumentUIRendering'
